### PR TITLE
Added html to MetaDataJsonCategory

### DIFF
--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -5,7 +5,7 @@ export type AnyPublicKey = StringPublicKey | PublicKey;
 
 export type ParamsWithStore<P> = P & { store: PublicKey };
 
-export type MetaDataJsonCategory = 'image' | 'video' | 'audio' | 'vr';
+export type MetaDataJsonCategory = 'image' | 'video' | 'audio' | 'vr' | 'html';
 
 export type MetadataJsonAttribute = {
   trait_type: string;


### PR DESCRIPTION
The `html` category was missing from `MetaDataJsonCategory`. See [here](https://github.com/metaplex-foundation/metaplex/blob/02fd9c0d1384bca247b2035cb85aa799a2cdf035/js/packages/common/src/actions/metadata.ts#L55) for the addition in the Metaplex repo.