### PR TITLE
[Tests] Use mock axios calls to avoid open handlers and speed up tests for Coingecko conversion

### DIFF
--- a/test/conversion.test.ts
+++ b/test/conversion.test.ts
@@ -1,9 +1,12 @@
 import { Coingecko, Currency } from '../src/providers/conversion';
+import axios, { AxiosResponse } from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.MockedFunction<typeof axios>;
 
 describe('Conversion', () => {
   let coingecko: Coingecko;
-
-  jest.setTimeout(80000);
 
   beforeAll(() => {
     // why not just do a static method? well, even though our current Coingecko implementation
@@ -15,35 +18,95 @@ describe('Conversion', () => {
 
   describe('Coingecko', () => {
     test('getRate single currency', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          arweave: {
+            usd: 53.44,
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      };
+      mockedAxios.mockResolvedValue(mockedResponse);
       const result = await coingecko.getRate(Currency.AR, Currency.USD);
       expect(result[0].from).toEqual(Currency.AR);
       expect(result[0].to).toEqual(Currency.USD);
-      expect(result[0].rate).toEqual(expect.any(Number));
+      expect(result[0].rate).toEqual(53.44);
     });
 
     test('getRate multiple to single currency', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          arweave: {
+            usd: 53.44,
+          },
+          solana: {
+            usd: 203.81,
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      };
+      mockedAxios.mockResolvedValue(mockedResponse);
+
       const result = await coingecko.getRate([Currency.AR, Currency.SOL], Currency.USD);
       expect(result[0].from).toEqual(Currency.AR);
       expect(result[0].to).toEqual(Currency.USD);
-      expect(result[0].rate).toEqual(expect.any(Number));
+      expect(result[0].rate).toEqual(53.44);
 
       expect(result[1].from).toEqual(Currency.SOL);
       expect(result[1].to).toEqual(Currency.USD);
-      expect(result[1].rate).toEqual(expect.any(Number));
+      expect(result[1].rate).toEqual(203.81);
     });
 
     test('getRate single to multiple currencies', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          arweave: {
+            usd: 53.44,
+            eur: 46.05,
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      };
+      mockedAxios.mockResolvedValue(mockedResponse);
+
       const result = await coingecko.getRate(Currency.AR, [Currency.USD, Currency.EUR]);
       expect(result[0].from).toEqual(Currency.AR);
       expect(result[0].to).toEqual(Currency.USD);
-      expect(result[0].rate).toEqual(expect.any(Number));
+      expect(result[0].rate).toEqual(53.44);
 
       expect(result[1].from).toEqual(Currency.AR);
       expect(result[1].to).toEqual(Currency.EUR);
-      expect(result[1].rate).toEqual(expect.any(Number));
+      expect(result[1].rate).toEqual(46.05);
     });
 
     test('getRate multiple to multiple currencies', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          arweave: {
+            usd: 53.44,
+            eur: 46.05,
+          },
+          solana: {
+            usd: 203.81,
+            eur: 175.69,
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      };
+      mockedAxios.mockResolvedValue(mockedResponse);
+
       const result = await coingecko.getRate(
         [Currency.AR, Currency.SOL],
         [Currency.USD, Currency.EUR],
@@ -51,19 +114,19 @@ describe('Conversion', () => {
 
       expect(result[0].from).toEqual(Currency.AR);
       expect(result[0].to).toEqual(Currency.USD);
-      expect(result[0].rate).toEqual(expect.any(Number));
+      expect(result[0].rate).toEqual(53.44);
 
       expect(result[1].from).toEqual(Currency.AR);
       expect(result[1].to).toEqual(Currency.EUR);
-      expect(result[1].rate).toEqual(expect.any(Number));
+      expect(result[1].rate).toEqual(46.05);
 
       expect(result[2].from).toEqual(Currency.SOL);
       expect(result[2].to).toEqual(Currency.USD);
-      expect(result[2].rate).toEqual(expect.any(Number));
+      expect(result[2].rate).toEqual(203.81);
 
       expect(result[3].from).toEqual(Currency.SOL);
       expect(result[3].to).toEqual(Currency.EUR);
-      expect(result[3].rate).toEqual(expect.any(Number));
+      expect(result[3].rate).toEqual(175.69);
     });
   });
 });


### PR DESCRIPTION
## Changes
- Mock axios responses instead of setting a timeout for the test that causes open handlers and slow down the test suite.

## Before

```
yarn test --detectOpenHandles test/conversion.test.ts                                                                                                                                             
yarn run v1.19.2                                                                                                                                                                                                   
$ jest --detectOpenHandles test/conversion.test.ts                                                                                                                                                                 
 PASS  test/conversion.test.ts                                                                                                                                                                                     
  Conversion                                                                                                                                                                                                       
    Coingecko                                                                                                                                                                                                      
      ✓ getRate single currency (302 ms)                                                                                                                                                                           
      ✓ getRate multiple to single currency (285 ms)                                                                                                                                                               
      ✓ getRate single to multiple currencies (217 ms)                                                                                                                                                             
      ✓ getRate multiple to multiple currencies (1857 ms)                                                                                                                                                          
                                                                                                                                                                                                                   
Test Suites: 1 passed, 1 total                                                                                                                                                                                     
Tests:       4 passed, 4 total                                                                                                                                                                                     
Snapshots:   0 total                                                                                                                                                                                               
Time:        3.743 s                                                                                                                                                                                               
Ran all test suites matching /test\/conversion.test.ts/i.                                                                                                                                                          
                                                                                                                                                                                                                   
Jest has detected the following 4 open handles potentially keeping Jest from exiting:        
Done in 5.97s.
```

## After

```
yarn test --detectOpenHandles test/conversion.test.ts
yarn run v1.19.2
$ jest --detectOpenHandles test/conversion.test.ts
 PASS  test/conversion.test.ts
  Conversion
    Coingecko
      ✓ getRate single currency (3 ms)
      ✓ getRate multiple to single currency (2 ms)
      ✓ getRate single to multiple currencies (1 ms)
      ✓ getRate multiple to multiple currencies (3 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.213 s, estimated 2 s
Ran all test suites matching /test\/conversion.test.ts/i.
Done in 3.45s.
```