### PR TITLE
fix: make getEdition a static method

### DIFF
--- a/src/programs/metadata/accounts/Metadata.ts
+++ b/src/programs/metadata/accounts/Metadata.ts
@@ -216,10 +216,7 @@ export class Metadata extends Account<MetadataData> {
     ).flat();
   }
 
-  async getEdition(connection: Connection) {
-    const mint = this.data?.mint;
-    if (!mint) return;
-
+  static async getEdition(connection: Connection, mint: AnyPublicKey) {
     const pda = await Edition.getPDA(mint);
     const info = await Account.getInfo(connection, pda);
     const key = info?.data[0];


### PR DESCRIPTION
`getEdition` seem like a really useful addition to the metadata class - but when it's not static it's kinda hard to use.

Not sure if there was a reason for it being like this, but I couldn't find any in the codebase. Also making it static seems in line with other methods on `Metadata`.

Lmk if I missed something ¯\_(ツ)_/¯