### PR TITLE
feat: added new actions for metadata program

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ const rates = await new Coingecko().getRate([Currency.AR, Currency.SOL], Currenc
       - [x] MintNewEditionFromMasterEditionViaToken
       - [ ] MintNewEditionFromMasterEditionViaVaultProxy
     - [ ] Actions
-      - [ ] Create
-      - [ ] Update
-      - [ ] Sign
+      - [X] Create
+      - [X] Update
+      - [X] Sign
       - [ ] Send
-      - [X] Mint
+      - [X] Mint Master Edition
+      - [X] Mint Limited Edition from Master
       - [ ] Burn
   - [ ] Metaplex
     - [ ] Accounts

--- a/src/actions/createMasterEdition.ts
+++ b/src/actions/createMasterEdition.ts
@@ -27,7 +27,7 @@ export const createMasterEdition = async (
     {
       edition,
       metadata,
-      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      updateAuthority: updateAuthority ?? wallet.publicKey,
       mint: editionMint,
       mintAuthority: wallet.publicKey,
       maxSupply,

--- a/src/actions/createMasterEdition.ts
+++ b/src/actions/createMasterEdition.ts
@@ -1,0 +1,42 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { Wallet } from '../wallet';
+import { CreateMasterEdition, MasterEdition, Metadata } from '../programs/metadata';
+import { sendTransaction } from './transactions';
+import BN from 'bn.js';
+
+interface CreateMasterEditionParams {
+  connection: Connection;
+  wallet: Wallet;
+  editionMint: PublicKey;
+  updateAuthority?: PublicKey;
+  maxSupply?: BN;
+}
+
+/*
+ * NOTE 1: a metadata account must already exist
+ * NOTE 2: must have exactly 1 editionMint token with 0 decimals outstanding
+ */
+export const createMasterEdition = async (
+  { connection, wallet, editionMint, updateAuthority, maxSupply } = {} as CreateMasterEditionParams,
+): Promise<string> => {
+  const metadata = await Metadata.getPDA(editionMint);
+  const edition = await MasterEdition.getPDA(editionMint);
+
+  const createMetadataTx = new CreateMasterEdition(
+    { feePayer: wallet.publicKey },
+    {
+      edition,
+      metadata,
+      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      mint: editionMint,
+      mintAuthority: wallet.publicKey,
+      maxSupply,
+    },
+  );
+  return sendTransaction({
+    connection,
+    signers: [],
+    txs: [createMetadataTx],
+    wallet,
+  });
+};

--- a/src/actions/createMetadata.ts
+++ b/src/actions/createMetadata.ts
@@ -21,7 +21,7 @@ export const createMetadata = async (
     {
       metadata,
       metadataData,
-      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      updateAuthority: updateAuthority ?? wallet.publicKey,
       mint: editionMint,
       mintAuthority: wallet.publicKey,
     },

--- a/src/actions/createMetadata.ts
+++ b/src/actions/createMetadata.ts
@@ -1,0 +1,35 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { Wallet } from '../wallet';
+import { CreateMetadata, Metadata, MetadataDataData } from '../programs/metadata';
+import { sendTransaction } from './transactions';
+
+interface CreateMetadataParams {
+  connection: Connection;
+  wallet: Wallet;
+  editionMint: PublicKey; // can be any mint with 0 decimals
+  metadataData: MetadataDataData;
+  updateAuthority?: PublicKey;
+}
+
+export const createMetadata = async (
+  { connection, wallet, editionMint, metadataData, updateAuthority } = {} as CreateMetadataParams,
+): Promise<string> => {
+  const metadata = await Metadata.getPDA(editionMint);
+
+  const createMetadataTx = new CreateMetadata(
+    { feePayer: wallet.publicKey },
+    {
+      metadata,
+      metadataData,
+      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      mint: editionMint,
+      mintAuthority: wallet.publicKey,
+    },
+  );
+  return sendTransaction({
+    connection,
+    signers: [],
+    txs: [createMetadataTx],
+    wallet,
+  });
+};

--- a/src/actions/mintEditionFromMaster.ts
+++ b/src/actions/mintEditionFromMaster.ts
@@ -27,7 +27,7 @@ interface MintEditionFromMasterResponse {
   edition: PublicKey;
 }
 
-export const mintEditionFromMaser = async (
+export const mintEditionFromMaster = async (
   { connection, wallet, masterEditionMint, updateAuthority } = {} as MintEditionFromMasterParams,
 ): Promise<MintEditionFromMasterResponse> => {
   const masterPDA = await MasterEdition.getPDA(masterEditionMint);
@@ -57,7 +57,7 @@ export const mintEditionFromMaser = async (
     {
       edition: editionPDA, //empty, created inside program
       metadata: metadataPDA, //empty, created inside program
-      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      updateAuthority: updateAuthority ?? wallet.publicKey,
       mint: mint.publicKey,
       mintAuthority: wallet.publicKey,
       masterEdition: masterPDA,

--- a/src/actions/mintEditionFromMaster.ts
+++ b/src/actions/mintEditionFromMaster.ts
@@ -1,0 +1,85 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { Wallet } from '../wallet';
+import {
+  Edition,
+  EditionMarker,
+  MasterEdition,
+  Metadata,
+  MintNewEditionFromMasterEditionViaToken,
+} from '../programs/metadata';
+import { Account } from '../Account';
+import BN from 'bn.js';
+import { prepareTokenAccountAndMintTx } from './shared';
+import { sendTransaction } from './transactions';
+
+interface MintEditionFromMasterParams {
+  connection: Connection;
+  wallet: Wallet;
+  masterEditionMint: PublicKey;
+  updateAuthority?: PublicKey;
+}
+
+interface MintEditionFromMasterResponse {
+  txId: string;
+  mint: PublicKey;
+  metadata: PublicKey;
+  edition: PublicKey;
+}
+
+export const mintEditionFromMaser = async (
+  { connection, wallet, masterEditionMint, updateAuthority } = {} as MintEditionFromMasterParams,
+): Promise<MintEditionFromMasterResponse> => {
+  const masterPDA = await MasterEdition.getPDA(masterEditionMint);
+  const masterMetaPDA = await Metadata.getPDA(masterEditionMint);
+  const masterInfo = await Account.getInfo(connection, masterPDA);
+  const masterData = new MasterEdition(masterPDA, masterInfo).data;
+
+  //take the current outstanding supply and increment by 1
+  const editionValue = masterData.supply.add(new BN(1));
+
+  const { mint, createMintTx, createAssociatedTokenAccountTx, mintToTx } =
+    await prepareTokenAccountAndMintTx(connection, wallet.publicKey);
+
+  const tokenAccount = await Token.getAssociatedTokenAddress(
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    masterEditionMint,
+    wallet.publicKey,
+  );
+
+  const metadataPDA = await Metadata.getPDA(mint.publicKey);
+  const editionMarker = await EditionMarker.getPDA(masterEditionMint, editionValue);
+  const editionPDA = await Edition.getPDA(mint.publicKey);
+
+  const newEditionFromMasterTx = new MintNewEditionFromMasterEditionViaToken(
+    { feePayer: wallet.publicKey },
+    {
+      edition: editionPDA, //empty, created inside program
+      metadata: metadataPDA, //empty, created inside program
+      updateAuthority: updateAuthority ? updateAuthority : wallet.publicKey,
+      mint: mint.publicKey,
+      mintAuthority: wallet.publicKey,
+      masterEdition: masterPDA,
+      masterMetadata: masterMetaPDA,
+      editionMarker, // empty if this is the 1st limited edition being created
+      tokenOwner: wallet.publicKey,
+      tokenAccount,
+      editionValue,
+    },
+  );
+
+  const txId = await sendTransaction({
+    connection,
+    signers: [mint],
+    txs: [createMintTx, createAssociatedTokenAccountTx, mintToTx, newEditionFromMasterTx],
+    wallet,
+  });
+
+  return {
+    txId,
+    mint: mint.publicKey,
+    metadata: metadataPDA,
+    edition: editionPDA,
+  };
+};

--- a/src/actions/shared/index.ts
+++ b/src/actions/shared/index.ts
@@ -1,0 +1,46 @@
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  MintLayout,
+  Token,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { CreateAssociatedTokenAccount, CreateMint, MintTo } from '../../programs';
+
+export async function prepareTokenAccountAndMintTx(connection: Connection, owner: PublicKey) {
+  const mint = Keypair.generate();
+  const mintRent = await connection.getMinimumBalanceForRentExemption(MintLayout.span);
+  const createMintTx = new CreateMint(
+    { feePayer: owner },
+    {
+      newAccountPubkey: mint.publicKey,
+      lamports: mintRent,
+    },
+  );
+
+  const recipient = await Token.getAssociatedTokenAddress(
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    mint.publicKey,
+    owner,
+  );
+
+  const createAssociatedTokenAccountTx = new CreateAssociatedTokenAccount(
+    { feePayer: owner },
+    {
+      associatedTokenAddress: recipient,
+      splTokenMintAddress: mint.publicKey,
+    },
+  );
+
+  const mintToTx = new MintTo(
+    { feePayer: owner },
+    {
+      mint: mint.publicKey,
+      dest: recipient,
+      amount: 1,
+    },
+  );
+
+  return { mint, createMintTx, createAssociatedTokenAccountTx, mintToTx };
+}

--- a/src/actions/signMetadata.ts
+++ b/src/actions/signMetadata.ts
@@ -23,7 +23,7 @@ export const signMetadata = async (
   );
   return await sendTransaction({
     connection,
-    signers: [signer ? signer : undefined],
+    signers: signer ? [signer] : [],
     txs: [signTx],
     wallet,
   });

--- a/src/actions/signMetadata.ts
+++ b/src/actions/signMetadata.ts
@@ -1,0 +1,30 @@
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { Wallet } from '../wallet';
+import { Metadata, SignMetadata } from '../programs/metadata';
+import { sendTransaction } from './transactions';
+
+interface SignMetadataParams {
+  connection: Connection;
+  wallet: Wallet;
+  editionMint: PublicKey;
+  signer?: Keypair;
+}
+
+export const signMetadata = async (
+  { connection, wallet, editionMint, signer } = {} as SignMetadataParams,
+): Promise<string> => {
+  const metadata = await Metadata.getPDA(editionMint);
+  const signTx = new SignMetadata(
+    { feePayer: wallet.publicKey },
+    {
+      metadata,
+      creator: signer ? signer.publicKey : wallet.publicKey,
+    },
+  );
+  return await sendTransaction({
+    connection,
+    signers: [signer ? signer : undefined],
+    txs: [signTx],
+    wallet,
+  });
+};

--- a/src/actions/updateMetadata.ts
+++ b/src/actions/updateMetadata.ts
@@ -1,0 +1,48 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { Wallet } from '../wallet';
+import { Metadata, MetadataDataData, UpdateMetadata } from '../programs/metadata';
+import { sendTransaction } from './transactions';
+
+interface UpdateMetadataParams {
+  connection: Connection;
+  wallet: Wallet;
+  editionMint: PublicKey;
+  newMetadataData?: MetadataDataData;
+  newUpdateAuthority?: PublicKey;
+  primarySaleHappened?: boolean;
+}
+
+/*
+ * Can be used to update any of the below 3:
+ * 1) data inside metadata, but only if it's mutable (which is only possible for MasterEditions)
+ * 2) updateAuthority
+ * 3) whether primary sale has happened (can only be set true, never back false)
+ */
+export const updateMetadata = async (
+  {
+    connection,
+    wallet,
+    editionMint,
+    newMetadataData,
+    newUpdateAuthority,
+    primarySaleHappened,
+  } = {} as UpdateMetadataParams,
+): Promise<string> => {
+  const metadata = await Metadata.getPDA(editionMint);
+  const updateTx = new UpdateMetadata(
+    { feePayer: wallet.publicKey },
+    {
+      metadata,
+      updateAuthority: wallet.publicKey,
+      metadataData: newMetadataData,
+      newUpdateAuthority,
+      primarySaleHappened,
+    },
+  );
+  return sendTransaction({
+    connection,
+    signers: [],
+    txs: [updateTx],
+    wallet,
+  });
+};

--- a/src/programs/metadata/transactions/UpdateMetadata.ts
+++ b/src/programs/metadata/transactions/UpdateMetadata.ts
@@ -20,8 +20,9 @@ export class UpdateMetadataArgs extends Borsh.Data<{
   ]);
 
   instruction = 1;
-  data: MetadataDataData | null = null;
-  updateAuthority: string | null = null;
+  // NOTE: do not add "=null". This breaks serialization.
+  data: MetadataDataData | null;
+  updateAuthority: string | null;
   primarySaleHappened: boolean | null;
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * as Borsh from './borsh';
 export * as Crypto from './crypto';
+export * as metadata from './metadata';
 export * from './tupleNumeric';

--- a/test/actions/createMetadataAndME.test.ts
+++ b/test/actions/createMetadataAndME.test.ts
@@ -1,0 +1,111 @@
+import { Keypair } from '@solana/web3.js';
+import axios, { AxiosResponse } from 'axios';
+import { Account, Connection, NodeWallet, Wallet } from '../../src';
+import { FEE_PAYER, pause } from '../utils';
+import { Creator, MasterEdition, Metadata, MetadataDataData } from '../../src/programs/metadata';
+import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { createMetadata } from '../../src/actions/createMetadata';
+import { createMasterEdition } from '../../src/actions/createMasterEdition';
+import BN from 'bn.js';
+
+jest.mock('axios');
+jest.setTimeout(150000); //this one takes particularly long
+
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
+
+// NOTE: testing the two together because latter effectively requires former
+describe('creatomg metadata and master edition PDAs', () => {
+  let connection: Connection;
+  let mint: Keypair;
+  let wallet: Wallet;
+
+  beforeAll(() => {
+    connection = new Connection('devnet');
+    wallet = new NodeWallet(FEE_PAYER);
+  });
+
+  beforeEach(() => {
+    mint = Keypair.generate();
+    const mockedResponse: AxiosResponse = {
+      data: {
+        name: 'Holo Design (0)',
+        symbol: '',
+        description:
+          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
+        seller_fee_basis_points: 100,
+        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
+        external_url: '',
+        properties: {
+          creators: [
+            {
+              address: wallet.publicKey.toString(),
+              share: 100,
+            },
+          ],
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+    mockedAxiosGet.mockResolvedValue(mockedResponse);
+  });
+
+  test('creates both successfully', async () => {
+    const mint = await Token.createMint(
+      connection,
+      FEE_PAYER,
+      wallet.publicKey,
+      wallet.publicKey,
+      0,
+      TOKEN_PROGRAM_ID,
+    );
+    const tokenAddress = await mint.createAssociatedTokenAccount(wallet.publicKey);
+    await mint.mintTo(tokenAddress, wallet.publicKey, [], 1);
+
+    const metadataData = new MetadataDataData({
+      name: 'xyzname',
+      symbol: 'xyz',
+      uri,
+      sellerFeeBasisPoints: 10,
+      creators: [
+        new Creator({
+          address: wallet.publicKey.toBase58(),
+          verified: false,
+          share: 100,
+        }),
+      ],
+    });
+
+    await createMetadata({
+      connection,
+      wallet,
+      editionMint: mint.publicKey,
+      metadataData,
+    });
+
+    await pause(20000);
+
+    const metadata = await Metadata.getPDA(mint.publicKey);
+    const metadataInfo = await Account.getInfo(connection, metadata);
+    const deserializedMetadataData = new Metadata(metadata, metadataInfo).data;
+    expect(deserializedMetadataData.data.name).toEqual('xyzname');
+
+    await createMasterEdition({
+      connection,
+      wallet,
+      editionMint: mint.publicKey,
+      maxSupply: new BN(100),
+    });
+
+    // had to increase to 25s, or it was failing
+    await pause(25000);
+
+    const edition = await MasterEdition.getPDA(mint.publicKey);
+    const editionInfo = await Account.getInfo(connection, edition);
+    const deserializedEditionData = new MasterEdition(edition, editionInfo).data;
+    expect(deserializedEditionData.maxSupply.toString(10)).toEqual('100');
+  });
+});

--- a/test/actions/createMetadataAndME.test.ts
+++ b/test/actions/createMetadataAndME.test.ts
@@ -1,56 +1,23 @@
 import { Keypair } from '@solana/web3.js';
-import axios, { AxiosResponse } from 'axios';
-import { Account, Connection, NodeWallet, Wallet } from '../../src';
+import { Account, Connection, NodeWallet } from '../../src';
 import { FEE_PAYER, pause } from '../utils';
 import { Creator, MasterEdition, Metadata, MetadataDataData } from '../../src/programs/metadata';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { createMetadata } from '../../src/actions/createMetadata';
 import { createMasterEdition } from '../../src/actions/createMasterEdition';
 import BN from 'bn.js';
+import { uri } from './shared';
 
-jest.mock('axios');
 jest.setTimeout(150000); //this one takes particularly long
-
-const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
-const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
 
 // NOTE: testing the two together because latter effectively requires former
 describe('creatomg metadata and master edition PDAs', () => {
-  let connection: Connection;
+  const connection = new Connection('devnet');
+  const wallet = new NodeWallet(FEE_PAYER);
   let mint: Keypair;
-  let wallet: Wallet;
-
-  beforeAll(() => {
-    connection = new Connection('devnet');
-    wallet = new NodeWallet(FEE_PAYER);
-  });
 
   beforeEach(() => {
     mint = Keypair.generate();
-    const mockedResponse: AxiosResponse = {
-      data: {
-        name: 'Holo Design (0)',
-        symbol: '',
-        description:
-          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
-        seller_fee_basis_points: 100,
-        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
-        external_url: '',
-        properties: {
-          creators: [
-            {
-              address: wallet.publicKey.toString(),
-              share: 100,
-            },
-          ],
-        },
-      },
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {},
-    };
-    mockedAxiosGet.mockResolvedValue(mockedResponse);
   });
 
   test('creates both successfully', async () => {

--- a/test/actions/mintEditionFromMaster.test.ts
+++ b/test/actions/mintEditionFromMaster.test.ts
@@ -3,7 +3,7 @@ import { Connection, NodeWallet, Wallet } from '../../src';
 import { mintNFT } from '../../src/actions';
 import { FEE_PAYER, pause } from '../utils';
 import { MasterEdition, Metadata } from '../../src/programs/metadata';
-import { mintEditionFromMaser } from '../../src/actions/mintEditionFromMaster';
+import { mintEditionFromMaster } from '../../src/actions/mintEditionFromMaster';
 import { mockAxios200, uri } from './shared';
 
 jest.mock('axios');
@@ -31,7 +31,7 @@ describe('minting a limited edition from master', () => {
     // empirically, I found anything below 20s to be unreliable
     await pause(20000);
 
-    const editionMintResponse = await mintEditionFromMaser({
+    const editionMintResponse = await mintEditionFromMaster({
       connection,
       wallet,
       masterEditionMint: masterMintResponse.mint,

--- a/test/actions/mintEditionFromMaster.test.ts
+++ b/test/actions/mintEditionFromMaster.test.ts
@@ -1,0 +1,78 @@
+import { Keypair } from '@solana/web3.js';
+import axios, { AxiosResponse } from 'axios';
+import { Connection, NodeWallet, Wallet } from '../../src';
+import { mintNFT } from '../../src/actions';
+import { FEE_PAYER, pause } from '../utils';
+import { MasterEdition, Metadata } from '../../src/programs/metadata';
+import { mintEditionFromMaser } from '../../src/actions/mintEditionFromMaster';
+
+jest.mock('axios');
+jest.setTimeout(100000);
+
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
+
+describe('minting a limited edition from master', () => {
+  let connection: Connection;
+  let mint: Keypair;
+  let wallet: Wallet;
+
+  beforeAll(() => {
+    connection = new Connection('devnet');
+    wallet = new NodeWallet(FEE_PAYER);
+  });
+
+  beforeEach(() => {
+    mint = Keypair.generate();
+    const mockedResponse: AxiosResponse = {
+      data: {
+        name: 'Holo Design (0)',
+        symbol: '',
+        description:
+          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
+        seller_fee_basis_points: 100,
+        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
+        external_url: '',
+        properties: {
+          creators: [
+            {
+              address: wallet.publicKey.toString(),
+              share: 100,
+            },
+          ],
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+    mockedAxiosGet.mockResolvedValue(mockedResponse);
+  });
+
+  test('mints successfully', async () => {
+    const masterMintResponse = await mintNFT({
+      connection,
+      wallet,
+      uri,
+      maxSupply: 100,
+    });
+
+    // unfortunately it takes some time for the master mint to propagate
+    // empirically, I found anything below 20s to be unreliable
+    await pause(20000);
+
+    const editionMintResponse = await mintEditionFromMaser({
+      connection,
+      wallet,
+      masterEditionMint: masterMintResponse.mint,
+    });
+
+    // the below is nice, but the real test is that the transaction went through w/o errors
+    const newEditionMint = editionMintResponse.mint;
+    const metadata = await Metadata.getPDA(newEditionMint);
+    const edition = await MasterEdition.getPDA(newEditionMint);
+    expect(editionMintResponse.edition).toEqual(edition);
+    expect(editionMintResponse.metadata).toEqual(metadata);
+  });
+});

--- a/test/actions/mintEditionFromMaster.test.ts
+++ b/test/actions/mintEditionFromMaster.test.ts
@@ -1,53 +1,22 @@
 import { Keypair } from '@solana/web3.js';
-import axios, { AxiosResponse } from 'axios';
 import { Connection, NodeWallet, Wallet } from '../../src';
 import { mintNFT } from '../../src/actions';
 import { FEE_PAYER, pause } from '../utils';
 import { MasterEdition, Metadata } from '../../src/programs/metadata';
 import { mintEditionFromMaser } from '../../src/actions/mintEditionFromMaster';
+import { mockAxios200, uri } from './shared';
 
 jest.mock('axios');
 jest.setTimeout(100000);
 
-const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
-const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
-
 describe('minting a limited edition from master', () => {
-  let connection: Connection;
+  const connection = new Connection('devnet');
+  const wallet = new NodeWallet(FEE_PAYER);
   let mint: Keypair;
-  let wallet: Wallet;
-
-  beforeAll(() => {
-    connection = new Connection('devnet');
-    wallet = new NodeWallet(FEE_PAYER);
-  });
 
   beforeEach(() => {
     mint = Keypair.generate();
-    const mockedResponse: AxiosResponse = {
-      data: {
-        name: 'Holo Design (0)',
-        symbol: '',
-        description:
-          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
-        seller_fee_basis_points: 100,
-        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
-        external_url: '',
-        properties: {
-          creators: [
-            {
-              address: wallet.publicKey.toString(),
-              share: 100,
-            },
-          ],
-        },
-      },
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {},
-    };
-    mockedAxiosGet.mockResolvedValue(mockedResponse);
+    mockAxios200(wallet);
   });
 
   test('mints successfully', async () => {
@@ -68,7 +37,6 @@ describe('minting a limited edition from master', () => {
       masterEditionMint: masterMintResponse.mint,
     });
 
-    // the below is nice, but the real test is that the transaction went through w/o errors
     const newEditionMint = editionMintResponse.mint;
     const metadata = await Metadata.getPDA(newEditionMint);
     const edition = await MasterEdition.getPDA(newEditionMint);

--- a/test/actions/mintNFT.test.ts
+++ b/test/actions/mintNFT.test.ts
@@ -1,10 +1,10 @@
-import { Keypair, PublicKey } from '@solana/web3.js';
+import { Keypair } from '@solana/web3.js';
 import axios, { AxiosResponse } from 'axios';
-import { Connection } from './../../src/Connection';
-import { NodeWallet, Wallet } from './../../src/wallet';
-import { mintNFT } from './../../src/actions';
-import { FEE_PAYER } from './../utils';
-import { MasterEdition, Metadata } from './../../src/programs/metadata';
+import { Connection } from '../../src';
+import { NodeWallet, Wallet } from '../../src';
+import { mintNFT } from '../../src/actions';
+import { FEE_PAYER } from '../utils';
+import { MasterEdition, Metadata } from '../../src/programs/metadata';
 
 jest.mock('axios');
 

--- a/test/actions/mintNFT.test.ts
+++ b/test/actions/mintNFT.test.ts
@@ -1,24 +1,19 @@
 import { Keypair } from '@solana/web3.js';
-import axios, { AxiosResponse } from 'axios';
-import { Connection } from '../../src';
-import { NodeWallet, Wallet } from '../../src';
+import axios from 'axios';
+import { Connection, NodeWallet, Wallet } from '../../src';
 import { mintNFT } from '../../src/actions';
 import { FEE_PAYER } from '../utils';
 import { MasterEdition, Metadata } from '../../src/programs/metadata';
+import { mockAxios200, mockAxios404, uri } from './shared';
 
 jest.mock('axios');
 
-const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
-const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
-
 describe('minting an NFT', () => {
-  let connection: Connection;
+  const connection = new Connection('devnet');
+  const wallet = new NodeWallet(FEE_PAYER);
   let mint: Keypair;
-  let wallet: Wallet;
 
   beforeAll(() => {
-    connection = new Connection('devnet');
-    wallet = new NodeWallet(FEE_PAYER);
     jest
       .spyOn(connection, 'sendRawTransaction')
       .mockResolvedValue(
@@ -33,32 +28,7 @@ describe('minting an NFT', () => {
 
   describe('when can find metadata json', () => {
     beforeEach(() => {
-      const mockedResponse: AxiosResponse = {
-        data: {
-          name: 'Holo Design (0)',
-          symbol: '',
-          description:
-            'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
-          seller_fee_basis_points: 100,
-          image:
-            'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
-          external_url: '',
-          properties: {
-            creators: [
-              {
-                address: wallet.publicKey.toString(),
-                share: 100,
-              },
-            ],
-          },
-        },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: {},
-      };
-
-      mockedAxiosGet.mockResolvedValue(mockedResponse);
+      mockAxios200(wallet);
     });
 
     test('generates a unique mint and creates metadata plus master edition from metadata URL and max supply', async () => {
@@ -82,15 +52,7 @@ describe('minting an NFT', () => {
 
   describe('when metadata json not found', () => {
     beforeEach(() => {
-      const mockedResponse: AxiosResponse = {
-        data: {},
-        status: 404,
-        statusText: 'NOT FOUND',
-        headers: {},
-        config: {},
-      };
-
-      mockedAxiosGet.mockRejectedValue(mockedResponse);
+      mockAxios404();
     });
 
     test('exits the action and throws an error', async () => {

--- a/test/actions/shared/index.ts
+++ b/test/actions/shared/index.ts
@@ -1,0 +1,54 @@
+import axios, { AxiosResponse } from 'axios';
+import { Wallet } from '../../../src';
+import { Keypair } from '@solana/web3.js';
+
+export const uri =
+  'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
+
+export const mockAxios200 = (wallet: Wallet, secondSigner: Keypair | undefined = undefined) => {
+  const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+  const mockedResponse: AxiosResponse = {
+    data: {
+      name: 'Holo Design (0)',
+      symbol: '',
+      description:
+        'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
+      seller_fee_basis_points: 100,
+      image: uri,
+      external_url: '',
+      properties: {
+        creators: [
+          {
+            address: wallet.publicKey.toString(),
+            verified: 1,
+            share: 100,
+          },
+        ],
+      },
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  };
+  if (secondSigner) {
+    mockedResponse.data.properties.creators.push({
+      address: secondSigner.publicKey.toString(),
+      verified: 0,
+      share: 0,
+    });
+  }
+  mockedAxiosGet.mockResolvedValue(mockedResponse);
+};
+
+export const mockAxios404 = () => {
+  const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+  const mockedResponse: AxiosResponse = {
+    data: {},
+    status: 404,
+    statusText: 'NOT FOUND',
+    headers: {},
+    config: {},
+  };
+  mockedAxiosGet.mockRejectedValue(mockedResponse);
+};

--- a/test/actions/signMetadata.test.ts
+++ b/test/actions/signMetadata.test.ts
@@ -1,0 +1,93 @@
+import { Keypair } from '@solana/web3.js';
+import axios, { AxiosResponse } from 'axios';
+import { Account, Connection, NodeWallet, Wallet } from '../../src';
+import { mintNFT } from '../../src/actions';
+import { FEE_PAYER, pause } from '../utils';
+import { Metadata } from '../../src/programs/metadata';
+import { signMetadata } from '../../src/actions/signMetadata';
+
+jest.mock('axios');
+jest.setTimeout(100000);
+
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
+
+describe('signing metadata on a master edition', () => {
+  let connection: Connection;
+  let mint: Keypair;
+  let secondSigner: Keypair;
+  let wallet: Wallet;
+
+  beforeAll(() => {
+    connection = new Connection('devnet');
+    wallet = new NodeWallet(FEE_PAYER);
+  });
+
+  beforeEach(() => {
+    mint = Keypair.generate();
+    secondSigner = Keypair.generate();
+    const mockedResponse: AxiosResponse = {
+      data: {
+        name: 'Holo Design (0)',
+        symbol: '',
+        description:
+          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
+        seller_fee_basis_points: 100,
+        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
+        external_url: '',
+        properties: {
+          creators: [
+            {
+              address: wallet.publicKey.toString(),
+              verified: 1,
+              share: 50,
+            },
+            {
+              address: secondSigner.publicKey.toString(),
+              verified: 0,
+              share: 50,
+            },
+          ],
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+    mockedAxiosGet.mockResolvedValue(mockedResponse);
+  });
+
+  test('signs successfully', async () => {
+    const masterMintResponse = await mintNFT({
+      connection,
+      wallet,
+      uri,
+      maxSupply: 100,
+    });
+
+    // unfortunately it takes some time for the master mint to propagate
+    // empirically, I found anything below 20s to be unreliable
+    await pause(20000);
+
+    // before update
+    const metadata = await Metadata.getPDA(masterMintResponse.mint);
+    let info = await Account.getInfo(connection, metadata);
+    let metadataData = new Metadata(metadata, info).data;
+    expect(metadataData.data.creators[1].verified).toEqual(0);
+
+    await signMetadata({
+      connection,
+      wallet,
+      editionMint: masterMintResponse.mint,
+      signer: secondSigner,
+    });
+
+    await pause(20000);
+
+    //after update
+    info = await Account.getInfo(connection, metadata);
+    metadataData = new Metadata(metadata, info).data;
+    expect(metadataData.data.creators[1].verified).toEqual(1);
+  });
+});

--- a/test/actions/updateMetadata.test.ts
+++ b/test/actions/updateMetadata.test.ts
@@ -1,0 +1,107 @@
+import { Keypair } from '@solana/web3.js';
+import axios, { AxiosResponse } from 'axios';
+import { Account, Connection, NodeWallet, Wallet } from '../../src';
+import { mintNFT } from '../../src/actions';
+import { FEE_PAYER, pause } from '../utils';
+import { Creator, Metadata, MetadataDataData } from '../../src/programs/metadata';
+import { updateMetadata } from '../../src/actions/updateMetadata';
+
+jest.mock('axios');
+jest.setTimeout(100000);
+
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
+const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
+
+describe('updating metadata on a master edition', () => {
+  let connection: Connection;
+  let mint: Keypair;
+  let wallet: Wallet;
+
+  beforeAll(() => {
+    connection = new Connection('devnet');
+    wallet = new NodeWallet(FEE_PAYER);
+  });
+
+  beforeEach(() => {
+    mint = Keypair.generate();
+    const mockedResponse: AxiosResponse = {
+      data: {
+        name: 'Holo Design (0)',
+        symbol: '',
+        description:
+          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
+        seller_fee_basis_points: 100,
+        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
+        external_url: '',
+        properties: {
+          creators: [
+            {
+              address: wallet.publicKey.toString(),
+              share: 100,
+            },
+          ],
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+    mockedAxiosGet.mockResolvedValue(mockedResponse);
+  });
+
+  test('updates successfully', async () => {
+    const newAuthority = Keypair.generate();
+
+    const newMetadataData = new MetadataDataData({
+      name: 'xyzname',
+      symbol: 'xyz',
+      uri: 'https://gateway.pinata.cloud/ipfs/QmNQh8noRHn7e7zt9oYNfGWuxHgKWkNPducMZs1SiZaYw4',
+      sellerFeeBasisPoints: 10,
+      creators: [
+        new Creator({
+          address: Keypair.generate().publicKey.toBase58(),
+          verified: false,
+          share: 100,
+        }),
+      ],
+    });
+
+    const masterMintResponse = await mintNFT({
+      connection,
+      wallet,
+      uri,
+      maxSupply: 100,
+    });
+
+    // unfortunately it takes some time for the master mint to propagate
+    // empirically, I found anything below 20s to be unreliable
+    await pause(20000);
+
+    // before update
+    const metadata = await Metadata.getPDA(masterMintResponse.mint);
+    let info = await Account.getInfo(connection, metadata);
+    let metadataData = new Metadata(metadata, info).data;
+    expect(metadataData.data.name).toEqual('Holo Design (0)');
+    expect(metadataData.updateAuthority).toEqual(wallet.publicKey.toBase58());
+    expect(metadataData.primarySaleHappened).toEqual(0);
+
+    await updateMetadata({
+      connection,
+      wallet,
+      editionMint: masterMintResponse.mint,
+      newMetadataData,
+      newUpdateAuthority: newAuthority.publicKey,
+      primarySaleHappened: true,
+    });
+
+    await pause(20000);
+
+    //after update
+    info = await Account.getInfo(connection, metadata);
+    metadataData = new Metadata(metadata, info).data;
+    expect(metadataData.data.name).toEqual('xyzname');
+    expect(metadataData.updateAuthority).toEqual(newAuthority.publicKey.toBase58());
+    expect(metadataData.primarySaleHappened).toEqual(1);
+  });
+});

--- a/test/actions/updateMetadata.test.ts
+++ b/test/actions/updateMetadata.test.ts
@@ -1,53 +1,23 @@
 import { Keypair } from '@solana/web3.js';
-import axios, { AxiosResponse } from 'axios';
-import { Account, Connection, NodeWallet, Wallet } from '../../src';
+import axios from 'axios';
+import { Account, Connection, NodeWallet } from '../../src';
 import { mintNFT } from '../../src/actions';
 import { FEE_PAYER, pause } from '../utils';
 import { Creator, Metadata, MetadataDataData } from '../../src/programs/metadata';
 import { updateMetadata } from '../../src/actions/updateMetadata';
+import { mockAxios200, uri } from './shared';
 
 jest.mock('axios');
 jest.setTimeout(100000);
 
-const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios>;
-const uri = 'https://bafkreibj4hjlhf3ehpugvfy6bzhhu2c7frvyhrykjqmoocsvdw24omfqga.ipfs.dweb.link';
-
 describe('updating metadata on a master edition', () => {
-  let connection: Connection;
+  const connection = new Connection('devnet');
+  const wallet = new NodeWallet(FEE_PAYER);
   let mint: Keypair;
-  let wallet: Wallet;
-
-  beforeAll(() => {
-    connection = new Connection('devnet');
-    wallet = new NodeWallet(FEE_PAYER);
-  });
 
   beforeEach(() => {
     mint = Keypair.generate();
-    const mockedResponse: AxiosResponse = {
-      data: {
-        name: 'Holo Design (0)',
-        symbol: '',
-        description:
-          'A holo of some design in a lovely purple, pink, and yellow. Pulled from the Internet. Demo only.',
-        seller_fee_basis_points: 100,
-        image: 'https://bafybeidq34cu23fq4u57xu3hp2usqqs7miszscyu4kjqyjo3hv7xea6upe.ipfs.dweb.link',
-        external_url: '',
-        properties: {
-          creators: [
-            {
-              address: wallet.publicKey.toString(),
-              share: 100,
-            },
-          ],
-        },
-      },
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {},
-    };
-    mockedAxiosGet.mockResolvedValue(mockedResponse);
+    mockAxios200(wallet);
   });
 
   test('updates successfully', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -84,3 +84,11 @@ export const mockTransaction: TransactionCtorFields = {
   recentBlockhash: RECENT_ISH_BLOCKHASH,
 };
 export const serializeConfig = { verifySignatures: false, requireAllSignatures: false };
+
+export async function pause(ms: number) {
+  await new Promise((response) =>
+    setTimeout(() => {
+      response(0);
+    }, ms),
+  );
+}


### PR DESCRIPTION
I've been using `metaplex/js` for a project and ended up writing some of the actions that were missing.

A few things to point out:

- Unfortunately tests need pretty big delays in them to succeed. This is because some actions are sequential and devent can be slow to propagate them. From trial and error, 20s delay seems to do it. This brings up the total test time from <30s to just over a minute. If that's too much of a pain, most waiting periods can be disabled (they're really mainly needed for deserializing accounts and asserting changes were successfully made - but we can also take a successfully completed tx as a proxy-indication. 
- I found an issue in `UpdateMetadata`, where because the below 2 lines were set to `= null`, borsh wasn't serializing data properly.
```
  data: MetadataDataData | null;
  updateAuthority: string | null;
```
- I don't know enough about borsh to tell why the `= null` was needed. Through trial and error removing it seems to fix the issue and didn't break any other tests.

Finally, I've left a few comments in the code to clarify parts I found confusing when coding this. I noticed the repo is basically comment-free - if that's an intentional decision, more than happy to remove. But I do think they're useful.

Hope this is useful!