### PR TITLE
fix: make max supply optional

### DIFF
--- a/src/actions/mintNFT.ts
+++ b/src/actions/mintNFT.ts
@@ -18,7 +18,7 @@ interface MintNFTParams {
   connection: Connection;
   wallet: Wallet;
   uri: string;
-  maxSupply: number;
+  maxSupply?: number;
 }
 
 interface MintNFTResponse {
@@ -90,7 +90,7 @@ export const mintNFT = async ({
       updateAuthority: wallet.publicKey,
       mint: mint.publicKey,
       mintAuthority: wallet.publicKey,
-      maxSupply: new BN(maxSupply),
+      maxSupply: maxSupply ? new BN(maxSupply) : null,
     },
   );
 


### PR DESCRIPTION
`CreateMasterEdition` downstream expects maxSupply as an optional param - no reason to make it a requirement at action level. In fact this makes it impossible to create an uncapped Master NFT.